### PR TITLE
remove gzip/deflate

### DIFF
--- a/lib/emaildirect.rb
+++ b/lib/emaildirect.rb
@@ -70,7 +70,6 @@ module EmailDirect
     headers({
       'User-Agent' => "emaildirect-rest-#{VERSION}",
       'Content-Type' => 'application/json; charset=utf-8',
-      'Accept-Encoding' => 'gzip, deflate',
       'ApiKey' => @@api_key
     })
     base_uri @@base_uri


### PR DESCRIPTION
Requests fails with JSON parser error, even when valid key is specified.

For more information, please refer to
https://github.com/jnunemaker/httparty/issues/562


