### PR TITLE
Add support for greater version of Hashie

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,22 @@
 PATH
   remote: .
   specs:
-    emaildirect (2.0.0)
-      hashie (<= 2.1.2)
+    emaildirect (3.0.0)
+      hashie
       httparty
       json
 
 GEM
   remote: http://rubygems.org/
   specs:
-    hashie (2.1.2)
-    httparty (0.15.5)
+    hashie (5.0.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (2.1.0)
+    json (2.6.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
     rake (11.1.2)
 
@@ -24,4 +28,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/emaildirect.gemspec
+++ b/emaildirect.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_runtime_dependency 'json'
-  s.add_runtime_dependency 'hashie', '<= 2.1.2'
+  s.add_runtime_dependency 'hashie'
   s.add_runtime_dependency 'httparty'
 end

--- a/lib/emaildirect.rb
+++ b/lib/emaildirect.rb
@@ -2,7 +2,9 @@ require 'cgi'
 require 'uri'
 require 'httparty'
 require 'hashie'
-Hash.send :include, Hashie::HashExtensions
+require 'emaildirect/extensions/hash'
+
+Hash.send :include, EmailDirect::Extensions::Hash
 
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)

--- a/lib/emaildirect/extensions/hash.rb
+++ b/lib/emaildirect/extensions/hash.rb
@@ -1,0 +1,34 @@
+module EmailDirect
+  module Extensions
+    # taken from Hashie::HashExtensions ( version 2.1.2 )
+    module Hash
+      def self.included(base)
+        # Don't tread on existing extensions of Hash by
+        # adding methods that are likely to exist.
+        %w(stringify_keys stringify_keys!).each do |hashie_method|
+          base.send :alias_method, hashie_method, "hashie_#{hashie_method}" unless base.instance_methods.include?(hashie_method)
+        end
+      end
+
+      # Destructively convert all of the keys of a Hash
+      # to their string representations.
+      def hashie_stringify_keys!
+        keys.each do |k|
+          self[k.to_s] = delete(k) unless String === k
+        end
+        self
+      end
+
+      # Convert all of the keys of a Hash
+      # to their string representations.
+      def hashie_stringify_keys
+        dup.stringify_keys!
+      end
+
+      # Convert this hash into a Mash
+      def to_mash
+        ::Hashie::Mash.new(self)
+      end
+    end
+  end
+end

--- a/lib/emaildirect/version.rb
+++ b/lib/emaildirect/version.rb
@@ -1,3 +1,3 @@
 module EmailDirect
-  VERSION = "2.0.0" unless defined?(EmailDirect::VERSION)
+  VERSION = "3.0.0" unless defined?(EmailDirect::VERSION)
 end


### PR DESCRIPTION
### Summary
* Add support for greater version of Hashie
* Had to copy Hashie::HashExtensions from 2.1.2  since was removed in version 3.0.0. in [PR https://github.com/hashie/hashie/pull/148](https://github.com/hashie/hashie/pull/148) 